### PR TITLE
Slack integration

### DIFF
--- a/src/Mero/Monolog/MonologComponent.php
+++ b/src/Mero/Monolog/MonologComponent.php
@@ -7,7 +7,9 @@ use Mero\Monolog\Exception\InvalidHandlerException;
 use Mero\Monolog\Exception\LoggerNotFoundException;
 use Mero\Monolog\Handler\YiiDbHandler;
 use Mero\Monolog\Handler\YiiMongoHandler;
+
 use Monolog\Formatter\FormatterInterface;
+
 use Monolog\Handler\AbstractHandler;
 use Monolog\Handler\BrowserConsoleHandler;
 use Monolog\Handler\ChromePHPHandler;
@@ -15,7 +17,9 @@ use Monolog\Handler\FirePHPHandler;
 use Monolog\Handler\GelfHandler;
 use Monolog\Handler\HipChatHandler;
 use Monolog\Handler\RotatingFileHandler;
+use Monolog\Handler\SlackHandler;
 use Monolog\Handler\StreamHandler;
+
 use yii\base\Component;
 use Monolog\Logger;
 use yii\di\Instance;
@@ -295,6 +299,37 @@ class MonologComponent extends Component
             case 'raven':
             case 'newrelic':
             case 'slack':
+                // Checking required parameters (token and slack channel)
+                if (!isset($config['token'])) {
+                    throw new InsufficientParametersException("Slack config 'token' has not been set");
+                }
+                if (!isset($config['channel'])) {
+                    throw new InsufficientParametersException("Slack config 'channel' has not been set");
+                }
+
+                $config = array_merge(
+                    [
+                        'username' => 'Monolog',
+                        'useAttachment' => true,
+                        'iconEmoji' => ":computer:",
+                        'bubble' => true,
+                        'useShortAttachment' => false,
+                        'includeContextAndExtra' => false,
+                    ],
+                    $config
+                );
+
+                return new SlackHandler(
+                    $config['token'],
+                    $config['channel'],
+                    $config['username'],
+                    $config['useAttachment'],
+                    $config['iconEmoji'],
+                    $config['level'],
+                    $config['bubble'],
+                    $config['useShortAttachment'],
+                    $config['includeContextAndExtra']
+                );
             case 'cube':
             case 'amqp':
             case 'error_log':
@@ -305,7 +340,6 @@ class MonologComponent extends Component
             case 'logentries':
             case 'flowdock':
             case 'rollbar':
-
                 return;
         }
     }

--- a/tests/Mero/Monolog/MonologComponentTest.php
+++ b/tests/Mero/Monolog/MonologComponentTest.php
@@ -80,6 +80,10 @@ class MonologComponentTest extends \PHPUnit_Framework_TestCase
                     'type' => 'hipchat',
                     'room' => 'XXXX',
                 ],
+                [
+                    'type' => 'slack',
+                    'channel' => 'XXXX',
+                ],
             ],
         ];
     }


### PR DESCRIPTION
This is the slack integration for the current `\Monolog\Handler\SlackHandler` that's using API tokens. This has been tested and works as expected with the following configuration:

``` php
'slack' => [
    'handler' => [
         [
            'type' => 'slack',
            'token' => 'XXXXXX',
            'channel' => 'my-test-channel',
            'formatter' => new \Monolog\Formatter\LineFormatter("%datetime% - %level_name%\t%message%\n"),
            'level' => 'debug',
        ],
    ],
    'processor' => [],
],
```

On a separate note, there's a high chance that the `Monolog\Handler\SlackHandler` changes in the next days/weeks to use webhooks instead of tokens, but apparently they don't plan to deprecate the token version so this should still be working. I will most certainly update this portion of code to handle the webhook version too.

Contact me in private if you need an access to a working slack channel, else the steps to get a slack token for your slack app are described here https://github.com/Seldaek/monolog/issues/743 (and is also leading to the discussion to use webhooks over tokens)
